### PR TITLE
Add a field to display if the talent level was increased via constellation

### DIFF
--- a/enka/clients/gi.py
+++ b/enka/clients/gi.py
@@ -167,7 +167,9 @@ class GenshinClient(BaseClient):
                 proud_id = proud_map.get(str(talent.id))
                 if proud_id is None:
                     continue
-                talent.level += character.talent_extra_level_map.get(str(proud_id), 0)
+                if extra_level := character.talent_extra_level_map.get(str(proud_id), 0):
+                    talent.level += extra_level
+                    talent.is_upgraded = True
 
         # talent order
         character.talent_order = character_data["SkillOrder"]

--- a/enka/models/gi/character.py
+++ b/enka/models/gi/character.py
@@ -197,12 +197,14 @@ class Talent(BaseModel):
         level (int): The talent's level.
         name (str): The talent's name.
         icon (str): The talent's icon.
+        is_upgraded (bool): Whether the talent is upgraded by a constellation.
     """
 
     id: int
     level: int
     name: str = Field(None)
     icon: str = Field(None)
+    is_upgraded: bool = Field(False)
 
 
 class Character(BaseModel):


### PR DESCRIPTION
Algo's enka cards change the text background if a talent level was increased by a constellation, as you can see here:
![image](https://github.com/seriaati/enka-py/assets/83609040/8d85020b-d736-438a-b926-05f2e3ac5940)

Currently I don't think that enka-py displays this, so I modified the Talent class to accommodate this.
(Also should probably add this for hsr traces as well but I haven't gotten around to it yet)