### PR TITLE
fix!: Fix typo in French enum name

### DIFF
--- a/enka/enums/hsr.py
+++ b/enka/enums/hsr.py
@@ -22,7 +22,7 @@ class Language(StrEnum):
     KOREAN = "ko"
     JAPANESE = "ja"
     INDOENSIAN = "id"
-    FRECH = "fr"
+    FRENCH = "fr"
     ESPANOL = "es"
     GERMAN = "de"
     TRADITIONAL_CHINESE = "zh-tw"


### PR DESCRIPTION
i just scrolled through the lib and witnessed this xD