### PR TITLE
Refactor icon property to return Optional[Icon]

### DIFF
--- a/enka/models/gi/costume.py
+++ b/enka/models/gi/costume.py
@@ -8,6 +8,12 @@ __all__ = ("Costume",)
 
 
 class Costume(BaseModel):
+    """Represents a character's costume.
+
+    Attributes:
+       id: The costume's ID.
+       icon: The costume's icon.
+    """
     id: int
     data: dict[str, Any]
 

--- a/enka/models/gi/costume.py
+++ b/enka/models/gi/costume.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import BaseModel, computed_field
 
@@ -8,18 +8,15 @@ __all__ = ("Costume",)
 
 
 class Costume(BaseModel):
-    """Represents a character's costume.
-
-    Attributes:
-       id: The costume's ID.
-       icon: The costume's icon.
-    """
-
     id: int
     data: dict[str, Any]
 
     @computed_field
     @property
-    def icon(self) -> Icon:
-        """The costume's icon."""
-        return Icon(side_icon_ui_path=self.data["SideIcon"], is_costume=True)
+    def icon(self) -> Optional[Icon]:
+        path = self.data.get("sideIconName")
+
+        if not path:
+            return None
+
+        return Icon(side_icon_ui_path=path, is_costume=True)

--- a/enka/models/gi/costume.py
+++ b/enka/models/gi/costume.py
@@ -14,6 +14,7 @@ class Costume(BaseModel):
        id: The costume's ID.
        icon: The costume's icon.
     """
+
     id: int
     data: dict[str, Any]
 


### PR DESCRIPTION
The Costume.icon computed field assumes that sideIconName is always present in the API response:

return Icon(side_icon_ui_path=self.data["sideIconName"], is_costume=True)

However, maybe some costumes returned by the Enka API do not include the sideIconName field. This leads to:

KeyError when accessing the field directly
After switching to .get(...), a ValidationError because None is passed to Icon, which expects a string

This error is triggered implicitly when:

calling print(response)
calling model_dump()
or any operation that evaluates computed field

response = await client.fetch_showcase(<UID>)
print(response)

Results in:

KeyError: 'sideIconName'

so i fixed it with treating it as optional
such that it prevents those issues